### PR TITLE
Remove `Forward` field

### DIFF
--- a/messages_test.go
+++ b/messages_test.go
@@ -310,12 +310,10 @@ func TestEnqueue(t *testing.T) {
 
 	res, err := client.Enqueue(EnqueueOptions{
 		Queue: "test-queue",
-		PublishOptions: PublishOptions{
-			Body: "test-body",
-			Url:  "https://example.com",
-			Headers: map[string]string{
-				"test-header": "test-value",
-			},
+		Body:  "test-body",
+		Url:   "https://example.com",
+		Headers: map[string]string{
+			"test-header": "test-value",
 		},
 	})
 	assert.NoError(t, err)
@@ -327,12 +325,10 @@ func TestEnqueueJSON(t *testing.T) {
 
 	res, err := client.EnqueueJSON(EnqueueJSONOptions{
 		Queue: "test-queue",
-		PublishJSONOptions: PublishJSONOptions{
-			Body: map[string]any{"test": "body"},
-			Url:  "https://example.com",
-			Headers: map[string]string{
-				"test-header": "test-value",
-			},
+		Body:  map[string]any{"test": "body"},
+		Url:   "https://example.com",
+		Headers: map[string]string{
+			"test-header": "test-value",
 		},
 	})
 	assert.NoError(t, err)
@@ -344,19 +340,17 @@ func TestEnqueueLlmApi(t *testing.T) {
 
 	res, err := client.EnqueueJSON(EnqueueJSONOptions{
 		Queue: "test-queue",
-		PublishJSONOptions: PublishJSONOptions{
-			Api: "llm",
-			Body: map[string]any{
-				"model": "meta-llama/Meta-Llama-3-8B-Instruct",
-				"messages": []map[string]string{
-					{
-						"role":    "user",
-						"content": "hello",
-					},
+		Api:   "llm",
+		Body: map[string]any{
+			"model": "meta-llama/Meta-Llama-3-8B-Instruct",
+			"messages": []map[string]string{
+				{
+					"role":    "user",
+					"content": "hello",
 				},
 			},
-			Callback: "http://example.com",
 		},
+		Callback: "http://example.com",
 	})
 
 	assert.NoError(t, err)

--- a/options.go
+++ b/options.go
@@ -22,7 +22,6 @@ type PublishOptions struct {
 	Retries                   *int
 	Callback                  string
 	FailureCallback           string
-	Forward                   string
 	Delay                     string
 	NotBefore                 string
 	DeduplicationId           string
@@ -56,7 +55,6 @@ type PublishUrlGroupOptions struct {
 	Retries                   *int
 	Callback                  string
 	FailureCallback           string
-	Forward                   string
 	Delay                     string
 	NotBefore                 string
 	DeduplicationId           string
@@ -90,7 +88,6 @@ type PublishJSONOptions struct {
 	Retries                   *int
 	Callback                  string
 	FailureCallback           string
-	Forward                   string
 	Delay                     string
 	NotBefore                 string
 	DeduplicationId           string
@@ -123,7 +120,6 @@ type PublishUrlGroupJSONOptions struct {
 	Retries                   *int
 	Callback                  string
 	FailureCallback           string
-	Forward                   string
 	Delay                     string
 	NotBefore                 string
 	DeduplicationId           string
@@ -149,8 +145,21 @@ func (m PublishUrlGroupJSONOptions) headers() http.Header {
 }
 
 type EnqueueOptions struct {
-	Queue string
-	PublishOptions
+	Queue                     string
+	Url                       string
+	Api                       string
+	Body                      string
+	Method                    string
+	ContentType               string
+	Headers                   map[string]string
+	Retries                   *int
+	Callback                  string
+	FailureCallback           string
+	Delay                     string
+	NotBefore                 string
+	DeduplicationId           string
+	ContentBasedDeduplication bool
+	Timeout                   string
 }
 
 func (m *EnqueueOptions) headers() http.Header {
@@ -171,8 +180,20 @@ func (m *EnqueueOptions) headers() http.Header {
 }
 
 type EnqueueUrlGroupOptions struct {
-	Queue string
-	PublishUrlGroupOptions
+	Queue                     string
+	UrlGroup                  string
+	Body                      string
+	Method                    string
+	ContentType               string
+	Headers                   map[string]string
+	Retries                   *int
+	Callback                  string
+	FailureCallback           string
+	Delay                     string
+	NotBefore                 string
+	DeduplicationId           string
+	ContentBasedDeduplication bool
+	Timeout                   string
 }
 
 func (m *EnqueueUrlGroupOptions) headers() http.Header {
@@ -193,8 +214,20 @@ func (m *EnqueueUrlGroupOptions) headers() http.Header {
 }
 
 type EnqueueJSONOptions struct {
-	Queue string
-	PublishJSONOptions
+	Queue                     string
+	Url                       string
+	Api                       string
+	Body                      map[string]any
+	Method                    string
+	Headers                   map[string]string
+	Retries                   *int
+	Callback                  string
+	FailureCallback           string
+	Delay                     string
+	NotBefore                 string
+	DeduplicationId           string
+	ContentBasedDeduplication bool
+	Timeout                   string
 }
 
 func (m *EnqueueJSONOptions) headers() http.Header {
@@ -215,8 +248,19 @@ func (m *EnqueueJSONOptions) headers() http.Header {
 }
 
 type EnqueueUrlGroupJSONOptions struct {
-	Queue string
-	PublishUrlGroupJSONOptions
+	Queue                     string
+	UrlGroup                  string
+	Body                      map[string]any
+	Method                    string
+	Headers                   map[string]string
+	Retries                   *int
+	Callback                  string
+	FailureCallback           string
+	Delay                     string
+	NotBefore                 string
+	DeduplicationId           string
+	ContentBasedDeduplication bool
+	Timeout                   string
 }
 
 func (m *EnqueueUrlGroupJSONOptions) headers() http.Header {
@@ -309,7 +353,6 @@ type BatchOptions struct {
 	Retries                   *int
 	Callback                  string
 	FailureCallback           string
-	Forward                   string
 	Delay                     string
 	NotBefore                 string
 	DeduplicationId           string
@@ -369,7 +412,6 @@ type BatchJSONOptions struct {
 	Retries                   *int
 	Callback                  string
 	FailureCallback           string
-	Forward                   string
 	Delay                     string
 	NotBefore                 string
 	DeduplicationId           string

--- a/url_group_test.go
+++ b/url_group_test.go
@@ -108,13 +108,11 @@ func TestEnqueueToUrlGroup(t *testing.T) {
 	assert.NoError(t, err)
 
 	res, err := client.UrlGroups().EnqueueJSON(EnqueueUrlGroupJSONOptions{
-		Queue: "test-queue",
-		PublishUrlGroupJSONOptions: PublishUrlGroupJSONOptions{
-			UrlGroup: name,
-			Body:     map[string]any{"test": "body"},
-			Headers: map[string]string{
-				"test-header": "test-value",
-			},
+		Queue:    "test-queue",
+		UrlGroup: name,
+		Body:     map[string]any{"test": "body"},
+		Headers: map[string]string{
+			"test-header": "test-value",
 		},
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
Forwarded headers are already passed through the `Headers` field, we don't need a separate `Forward` field.

Additionally, this PR embeds `Publish...Options` fields directly in `Enqueue..Options` structs to improve the developer experience. Creating multiple options objects to enqueue a message was not very useful.